### PR TITLE
SVCPLAN-9125: Delta - prevent dismissal of announcements

### DIFF
--- a/gh-ondemand.delta.ncsa.illinois.edu/announcements/announcement.md
+++ b/gh-ondemand.delta.ncsa.illinois.edu/announcements/announcement.md
@@ -1,1 +1,0 @@
-Welcome to Open OnDemand for DeltaAI.

--- a/gh-ondemand.delta.ncsa.illinois.edu/announcements/announcement.yml
+++ b/gh-ondemand.delta.ncsa.illinois.edu/announcements/announcement.yml
@@ -1,0 +1,5 @@
+---
+dismissible: false
+message: |
+  Welcome to Open OnDemand for DeltaAI.
+type: info

--- a/gh-testondemand.delta.ncsa.illinois.edu/announcements/announcement.md
+++ b/gh-testondemand.delta.ncsa.illinois.edu/announcements/announcement.md
@@ -1,1 +1,0 @@
-Welcome to Open OnDemand for DeltaAI.

--- a/gh-testondemand.delta.ncsa.illinois.edu/announcements/announcement.yml
+++ b/gh-testondemand.delta.ncsa.illinois.edu/announcements/announcement.yml
@@ -1,0 +1,5 @@
+---
+dismissible: false
+message: |
+  Welcome to Open OnDemand for DeltaAI.
+type: info

--- a/ood-test.delta.ncsa.illinois.edu/announcements/announcement.md
+++ b/ood-test.delta.ncsa.illinois.edu/announcements/announcement.md
@@ -1,5 +1,0 @@
-Welcome to NCSA's Delta system.
-
-- For general Open OnDemand information, please see [the Open OnDemand section of the Delta User Guide](https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/ood/index.html).
-- While development in Jupyter can be done in the -interactive partitions (with 1 hour wall clock limit), longer running Jupyter sessions need to use the standard partitions (up to 48 hour wall clock limits).  You can find [a list of all available Slurm partitions on Delta](https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/running_jobs.html#delta-production-partitions-queues) in the Delta User Guide.
-- Requests for assistance should go to [help@ncsa.illinois.edu](mailto:help@ncsa.illinois.edu). Please mention Delta in the subject to ensure the request gets correctly routed.

--- a/ood-test.delta.ncsa.illinois.edu/announcements/announcement.yml
+++ b/ood-test.delta.ncsa.illinois.edu/announcements/announcement.yml
@@ -1,0 +1,9 @@
+---
+dismissible: false
+message: |
+  Welcome to NCSA's Delta system.
+
+  - For general Open OnDemand information, please see [the Open OnDemand section of the Delta User Guide](https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/ood/index.html).
+  - While development in Jupyter can be done in the -interactive partitions (with 1 hour wall clock limit), longer running Jupyter sessions need to use the standard partitions (up to 48 hour wall clock limits).  You can find [a list of all available Slurm partitions on Delta](https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/running_jobs.html#delta-production-partitions-queues) in the Delta User Guide.
+  - Requests for assistance should go to [help@ncsa.illinois.edu](mailto:help@ncsa.illinois.edu). Please mention Delta in the subject to ensure the request gets correctly routed.
+type: info

--- a/openondemand.delta.ncsa.illinois.edu/announcements/announcement.md
+++ b/openondemand.delta.ncsa.illinois.edu/announcements/announcement.md
@@ -1,5 +1,0 @@
-Welcome to NCSA's Delta system.
-
-- For general Open OnDemand information, please see [the Open OnDemand section of the Delta User Guide](https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/ood/index.html).
-- While development in Jupyter can be done in the -interactive partitions (with 1 hour wall clock limit), longer running Jupyter sessions need to use the standard partitions (up to 48 hour wall clock limits).  You can find [a list of all available Slurm partitions on Delta](https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/running_jobs.html#delta-production-partitions-queues) in the Delta User Guide.
-- Requests for assistance should go to [help@ncsa.illinois.edu](mailto:help@ncsa.illinois.edu). Please mention Delta in the subject to ensure the request gets correctly routed.

--- a/openondemand.delta.ncsa.illinois.edu/announcements/announcement.yml
+++ b/openondemand.delta.ncsa.illinois.edu/announcements/announcement.yml
@@ -1,0 +1,9 @@
+---
+dismissible: false
+message: |
+  Welcome to NCSA's Delta system.
+
+  - For general Open OnDemand information, please see [the Open OnDemand section of the Delta User Guide](https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/ood/index.html).
+  - While development in Jupyter can be done in the -interactive partitions (with 1 hour wall clock limit), longer running Jupyter sessions need to use the standard partitions (up to 48 hour wall clock limits).  You can find [a list of all available Slurm partitions on Delta](https://docs.ncsa.illinois.edu/systems/delta/en/latest/user_guide/running_jobs.html#delta-production-partitions-queues) in the Delta User Guide.
+  - Requests for assistance should go to [help@ncsa.illinois.edu](mailto:help@ncsa.illinois.edu). Please mention Delta in the subject to ensure the request gets correctly routed.
+type: info


### PR DESCRIPTION
With the upgrade of OOD from v3(.1) to v4(.2) announcements can be dismissible by users. This is the default.

To prevent this, we must convert from .md to .yml (with embedded markdown) and set 'dismissible: false'.

Just doing this for our main, "active" announcement files. We can address for others when editing later.